### PR TITLE
allow JSON string as listdata argument

### DIFF
--- a/R/jsonedit.R
+++ b/R/jsonedit.R
@@ -5,8 +5,10 @@
 #'   Eventually, this could become a very nice way to not only view but also modify R data using
 #'   Shiny.
 #'
-#' @param listdata \code{list} data to view.  Although designed for \code{lists}, \code{listdata} can
-#'          be any data source that can be rendered into \code{JSON} with \code{jsonlite}.
+#' @param listdata \code{list} or \code{String} data to view.  Although designed for \code{lists}, \code{listdata} can
+#'          be any data source that can be rendered into \code{JSON} with \code{jsonlite}.  Alternately,
+#'          \code{listdata} could be a \code{String} of valid \code{JSON}.  This might be helpful
+#'          when dealing with an API response.
 #' @param mode \code{string} for the initial view from \code{modes}.  \code{'tree'} is the default.
 #' @param modes \code{string} \code{c('code', 'form', 'text', 'tree', 'view')} will be the default, since
 #'          these are all the modes currently supported by \code{jsoneditor}.
@@ -30,6 +32,11 @@
 #'        ,object = list( a="b", c="d" )
 #'        ,string = "Hello World"
 #'      )
+#'    )
+#'
+#'    # jsonedit also works with a JSON string
+#'    jsonedit(
+#'      '{"array" : [1,2,3] , "boolean" : true, "null" : null, number = 123}'
 #'    )
 #'
 #'    # also works with most data.frames

--- a/inst/htmlwidgets/jsonedit.js
+++ b/inst/htmlwidgets/jsonedit.js
@@ -18,12 +18,10 @@ HTMLWidgets.widget({
     el.innerHTML = "";
 
     // create our editor
-    var editor = new JSONEditor( el, x.options, x.data );
+    var editor = new JSONEditor( el, x.options, (typeof(x.data)==="string") ? JSON.parse(x.data) : x.data );
 
     // use expando property to store editor for change callback potential
     el.editor = editor;
-
-    instance.editor = editor;
 
   },
 

--- a/man/jsonedit.Rd
+++ b/man/jsonedit.Rd
@@ -8,8 +8,10 @@ jsonedit(listdata = NULL, mode = "tree", modes = c("code", "form", "text",
   "tree", "view"), ..., width = NULL, height = NULL)
 }
 \arguments{
-\item{listdata}{\code{list} data to view.  Although designed for \code{lists}, \code{listdata} can
-be any data source that can be rendered into \code{JSON} with \code{jsonlite}.}
+\item{listdata}{\code{list} or \code{String} data to view.  Although designed for \code{lists}, \code{listdata} can
+be any data source that can be rendered into \code{JSON} with \code{jsonlite}.  Alternately,
+\code{listdata} could be a \code{String} of valid \code{JSON}.  This might be helpful
+when dealing with an API response.}
 
 \item{mode}{\code{string} for the initial view from \code{modes}.  \code{'tree'} is the default.}
 
@@ -45,6 +47,11 @@ in favor of specific, more self-documenting and helpful arguments.}
        ,object = list( a="b", c="d" )
        ,string = "Hello World"
      )
+   )
+
+   # jsonedit also works with a JSON string
+   jsonedit(
+     '{"array" : [1,2,3] , "boolean" : true, "null" : null, number = 123}'
    )
 
    # also works with most data.frames


### PR DESCRIPTION
This pull documents on the `R` side and adds a conditional on the `JavaScript` side to allow the `listdata` argument to also be a `JSON` string using `JSON.parse()`.  Partially addresses #1 since does not work with `XML` strings yet.