### PR TITLE
disable edit when onEdit==FALSE

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: listviewer
 Type: Package
 Title: 'htmlwidget' for Interactive Views of R Lists
-Version: 2.1.0
+Version: 2.1.1
 Date: 2018-10-06
 Authors@R: c(
     person("Jos", "de Jong", role = c("aut", "cph"), comment = "jsoneditor.js library in htmlwidgets/jsoneditor, http://github.com/josdejong/jsoneditor/" ),

--- a/inst/htmlwidgets/reactjson.js
+++ b/inst/htmlwidgets/reactjson.js
@@ -30,10 +30,10 @@ HTMLWidgets.widget({
                 enableClipboard: x.enableClipboard,
                 displayObjectSize: x.displayObjectSize,
                 displayDataTypes: x.displayDataTypes,
-                onEdit: x.onEdit ? x.onEdit : function(value) {logChange(value,"edit")},
-                onAdd: x.onAdd ? x.onAdd : function(value) {logChange(value,"add")},
-                onDelete: x.onDelete ? x.onDelete : function(value) {logChange(value,"delete")},
-                onSelect: x.onSelect ? x.onSelect : function(value) {logChange(value,"select")},
+                onEdit: x.onEdit ? function(value) {logChange(value,"edit")} : x.onEdit,
+                onAdd: x.onAdd ? function(value) {logChange(value,"add")} : x.onAdd,
+                onDelete: x.onDelete ? function(value) {logChange(value,"delete")} : x.onDelete,
+                onSelect: x.onSelect ? function(value) {logChange(value,"select")} : x.onSelect,
                 sortKeys: x.sortKeys
               }
             ),


### PR DESCRIPTION
Hello,
In the current version, when onEdit=T, the edit icon stays on the view, but it cannot be edited. When onEdit=F, it can be edited. It is the same beharvior for onDelete, onAdd and OnSelect. Is it an issue? Things seems inverted on the following lines https://github.com/timelyportfolio/listviewer/blob/107e5cb66da7b432c6874df25cccdd00a7533b20/inst/htmlwidgets/reactjson.js#L33-L36.
Regards,
Alassane